### PR TITLE
fix: `CallBreaker.getCompleteCallIndexList` only return correct indexes.

### DIFF
--- a/src/timetravel/CallBreaker.sol
+++ b/src/timetravel/CallBreaker.sol
@@ -156,10 +156,22 @@ contract CallBreaker is CallBreakerStorage {
     /// @param callObj The callObj to search for
     function getCompleteCallIndexList(CallObject calldata callObj) public view returns (uint256[] memory) {
         bytes32 callId = keccak256(abi.encode(callObj));
-        uint256[] memory index = new uint256[](callList.length);
+
+        // First, determine the count of matching elements
+        uint256 count = 0;
         for (uint256 i = 0; i < callList.length; i++) {
             if (callList[i].callId == callId) {
-                index[i] = i;
+                count++;
+            }
+        }
+
+        // Allocate the result array with the correct size
+        uint256[] memory index = new uint256[](count);
+        uint256 j = 0;
+        for (uint256 i = 0; i < callList.length; i++) {
+            if (callList[i].callId == callId) {
+                index[j] = i;
+                j++;
             }
         }
         return index;

--- a/test/CallBreaker.t.sol
+++ b/test/CallBreaker.t.sol
@@ -340,13 +340,32 @@ contract CallBreakerTest is Test {
     }
 
     function testGetCompleteCallIndexList() external {
-        CallObject[] memory calls = new CallObject[](1);
+        CallObject[] memory calls = new CallObject[](3);
         calls[0] = CallObject({amount: 0, addr: address(0xdeadbeef), gas: 1000000, callvalue: ""});
-        ReturnObject[] memory returnValues = new ReturnObject[](1);
+        calls[1] = CallObject({amount: 0, addr: address(0xbeefdead), gas: 1000000, callvalue: ""});
+        calls[2] = CallObject({amount: 0, addr: address(0xdeadbeef), gas: 1000000, callvalue: ""});
+
+        ReturnObject[] memory returnValues = new ReturnObject[](3);
         returnValues[0] = ReturnObject({returnvalue: ""});
+        returnValues[1] = ReturnObject({returnvalue: ""});
+        returnValues[2] = ReturnObject({returnvalue: ""});
+
         callbreaker.resetTraceStoresWithHarness(calls, returnValues);
         callbreaker.populateCallIndicesHarness();
-        callbreaker.getCompleteCallIndexList(calls[0]);
+
+        CallObject memory doubleCall = calls[0];
+        uint256[] memory doubleCallExpected = new uint256[](2);
+        doubleCallExpected[0] = 0;
+        doubleCallExpected[1] = 2;
+        assertEq(doubleCallExpected, callbreaker.getCompleteCallIndexList(doubleCall));
+
+        CallObject memory singleCall = calls[1];
+        uint256[] memory singleCallExpected = new uint256[](1);
+        singleCallExpected[0] = 1;
+        assertEq(singleCallExpected, callbreaker.getCompleteCallIndexList(singleCall));
+
+        CallObject memory falseCall = CallObject({amount: 0, addr: address(0xbabe), gas: 1000000, callvalue: ""});
+        assertEq(new uint256[](0), callbreaker.getCompleteCallIndexList(falseCall));
     }
 
     function testFetchFromAssociatedDataStore() external {


### PR DESCRIPTION
### Overview

The bug in the Solidity function `getCompleteCallIndexList` is that it initializes an array index with the length of `callList`, but it only assigns values to some of its elements, leaving others as default values (zero). When returning this array, it contains many unnecessary zeros, which is likely not the intended behavior.

A better approach is to first determine how many elements match the `callId`, allocate an array of that exact size, and then populate it.