### PR TITLE
Fix data store and load in call obj holder

### DIFF
--- a/src/TimeTypes.sol
+++ b/src/TimeTypes.sol
@@ -78,6 +78,7 @@ struct CallObjectHolderStorage {
     bool executed;
     uint40 firstCallableBlock;
     uint256 executionNonce;
+    bytes data;
     genericDynArrayHead callObjsHead;
     genericDynArrayElementsSlot callObjsElements;
 }
@@ -110,6 +111,7 @@ library CallObjectLib {
 
         holderStorage.callObjsHead = callObjsHead;
         holderStorage.executionNonce = holder.nonce;
+        holderStorage.data = abi.encode(holder.data);
     }
 
     function store(CallObjectStorage storage callObjStorage, CallObject memory callObj) internal {
@@ -135,6 +137,8 @@ library CallObjectLib {
         holder.initialized = holderStorage.initialized;
         holder.executed = holderStorage.executed;
         holder.firstCallableBlock = holderStorage.firstCallableBlock;
+        holder.nonce = holderStorage.executionNonce;
+        holder.data = _getDecodedData(holderStorage.data);
         uint256 len = holderStorage.callObjsHead.length();
         holder.callObjs = new CallObject[](len);
 
@@ -171,6 +175,12 @@ library CallObjectLib {
         /// @solidity memory-safe-assembly
         assembly {
             callObj.slot := ptr
+        }
+    }
+
+    function _getDecodedData(bytes memory encodedData) internal pure returns (SolverData[] memory solverData) {
+        if (encodedData.length != 0) {
+            solverData = abi.decode(encodedData, (SolverData[]));
         }
     }
 }

--- a/test/examples/MEVOracle/KITNDisburmentScheduler.sol
+++ b/test/examples/MEVOracle/KITNDisburmentScheduler.sol
@@ -75,7 +75,7 @@ contract KITNDisburmentScheduler is SmarterContract, Ownable {
         // require(signer == owner(), "CleanAppKITNDisbursal: Verification Failed");
     }
 
-    function getEthSignedMessageHash(bytes memory data) public view returns (bytes32) {
+    function getEthSignedMessageHash(bytes memory data) public pure returns (bytes32) {
         return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", data));
     }
 }


### PR DESCRIPTION
This PR fixes the problem of Additional data not being stored, loaded and copied correctly in the CallObjectHolder of LaminatedProxy